### PR TITLE
fix check for configured soundsystem

### DIFF
--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -191,7 +191,7 @@ int Conf::read()
 	logMode = atoi(getValue("logMode").c_str());
 
 	soundSystem = atoi(getValue("soundSystem").c_str());
-	if (!soundSystem & (SYS_API_ANY)) soundSystem = DEFAULT_SOUNDSYS;
+	if (!(soundSystem & SYS_API_ANY)) soundSystem = DEFAULT_SOUNDSYS;
 
 	soundDeviceOut = atoi(getValue("soundDeviceOut").c_str());
 	if (soundDeviceOut < 0) soundDeviceOut = DEFAULT_SOUNDDEV_OUT;


### PR DESCRIPTION
as [reported in Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=791544), the code that checks the validity of the configured soundsystem breaks when compiling with g++5 and strict format checking (`-Werror  -Wformat -Werror=format-security`).

indeed the check is valid and th ecode is bogus: `(!soundSystem & (SYS_API_ANY))` is really `((!soundSystem) & (SYS_API_ANY))`.
this will only evaluate to true is `soundSystem==0`, in which here is no need to `&` it with `SYS_API_ANY`.

i think my patch is closer to the original intention (use the default soundsystem if no other soundsystem is chosen explicitely)